### PR TITLE
fix: Remove References of MaintainersCanModify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # go-github #
 
+## About this fork ##
+
+This fork removes all mentioned of `MaintainerCanModify` and `maintainer_can_modify` fields from the library, which essentially blocks PRs under organization repos from being modified by people with `Admin` or `Maintain` privilege. This behavior has been confirmed as unexpected Github Support, hence this fork was made.
+
 [![go-github release (latest SemVer)](https://img.shields.io/github/v/release/google/go-github?sort=semver)](https://github.com/google/go-github/releases)
 [![GoDoc](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/google/go-github/v56/github)
 [![Test Status](https://github.com/google/go-github/workflows/tests/badge.svg)](https://github.com/google/go-github/actions?query=workflow%3Atests)

--- a/example/commitpr/main.go
+++ b/example/commitpr/main.go
@@ -190,7 +190,6 @@ func createPR() (err error) {
 		HeadRepo:            repoBranch,
 		Base:                prBranch,
 		Body:                prDescription,
-		MaintainerCanModify: github.Bool(true),
 	}
 
 	pr, _, err := client.PullRequests.Create(ctx, *prRepoOwner, *prRepo, newPR)

--- a/github/examples_test.go
+++ b/github/examples_test.go
@@ -121,11 +121,10 @@ func ExamplePullRequestsService_Create() {
 	client := github.NewClient(nil)
 
 	newPR := &github.NewPullRequest{
-		Title:               github.String("My awesome pull request"),
-		Head:                github.String("branch_to_merge"),
-		Base:                github.String("master"),
-		Body:                github.String("This is the description of the PR created with the package `github.com/google/go-github/github`"),
-		MaintainerCanModify: github.Bool(true),
+		Title: github.String("My awesome pull request"),
+		Head:  github.String("branch_to_merge"),
+		Base:  github.String("master"),
+		Body:  github.String("This is the description of the PR created with the package `github.com/google/go-github/github`"),
 	}
 
 	ctx := context.Background()

--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -11974,14 +11974,6 @@ func (n *NewPullRequest) GetIssue() int {
 	return *n.Issue
 }
 
-// GetMaintainerCanModify returns the MaintainerCanModify field if it's non-nil, zero value otherwise.
-func (n *NewPullRequest) GetMaintainerCanModify() bool {
-	if n == nil || n.MaintainerCanModify == nil {
-		return false
-	}
-	return *n.MaintainerCanModify
-}
-
 // GetTitle returns the Title field if it's non-nil, zero value otherwise.
 func (n *NewPullRequest) GetTitle() string {
 	if n == nil || n.Title == nil {
@@ -15868,14 +15860,6 @@ func (p *PullRequest) GetLocked() bool {
 		return false
 	}
 	return *p.Locked
-}
-
-// GetMaintainerCanModify returns the MaintainerCanModify field if it's non-nil, zero value otherwise.
-func (p *PullRequest) GetMaintainerCanModify() bool {
-	if p == nil || p.MaintainerCanModify == nil {
-		return false
-	}
-	return *p.MaintainerCanModify
 }
 
 // GetMergeable returns the Mergeable field if it's non-nil, zero value otherwise.

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -13996,16 +13996,6 @@ func TestNewPullRequest_GetIssue(tt *testing.T) {
 	n.GetIssue()
 }
 
-func TestNewPullRequest_GetMaintainerCanModify(tt *testing.T) {
-	var zeroValue bool
-	n := &NewPullRequest{MaintainerCanModify: &zeroValue}
-	n.GetMaintainerCanModify()
-	n = &NewPullRequest{}
-	n.GetMaintainerCanModify()
-	n = nil
-	n.GetMaintainerCanModify()
-}
-
 func TestNewPullRequest_GetTitle(tt *testing.T) {
 	var zeroValue string
 	n := &NewPullRequest{Title: &zeroValue}
@@ -18438,16 +18428,6 @@ func TestPullRequest_GetLocked(tt *testing.T) {
 	p.GetLocked()
 	p = nil
 	p.GetLocked()
-}
-
-func TestPullRequest_GetMaintainerCanModify(tt *testing.T) {
-	var zeroValue bool
-	p := &PullRequest{MaintainerCanModify: &zeroValue}
-	p.GetMaintainerCanModify()
-	p = &PullRequest{}
-	p.GetMaintainerCanModify()
-	p = nil
-	p.GetMaintainerCanModify()
 }
 
 func TestPullRequest_GetMergeable(tt *testing.T) {

--- a/github/github-stringify_test.go
+++ b/github/github-stringify_test.go
@@ -1292,7 +1292,6 @@ func TestPullRequest_String(t *testing.T) {
 		ReviewComments:      Int(0),
 		Assignee:            &User{},
 		Milestone:           &Milestone{},
-		MaintainerCanModify: Bool(false),
 		AuthorAssociation:   String(""),
 		NodeID:              String(""),
 		AutoMerge:           &PullRequestAutoMerge{},
@@ -1301,7 +1300,7 @@ func TestPullRequest_String(t *testing.T) {
 		Base:                &PullRequestBranch{},
 		ActiveLockReason:    String(""),
 	}
-	want := `github.PullRequest{ID:0, Number:0, State:"", Locked:false, Title:"", Body:"", CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, ClosedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, MergedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, User:github.User{}, Draft:false, Merged:false, Mergeable:false, MergeableState:"", MergedBy:github.User{}, MergeCommitSHA:"", Rebaseable:false, Comments:0, Commits:0, Additions:0, Deletions:0, ChangedFiles:0, URL:"", HTMLURL:"", IssueURL:"", StatusesURL:"", DiffURL:"", PatchURL:"", CommitsURL:"", CommentsURL:"", ReviewCommentsURL:"", ReviewCommentURL:"", ReviewComments:0, Assignee:github.User{}, Milestone:github.Milestone{}, MaintainerCanModify:false, AuthorAssociation:"", NodeID:"", AutoMerge:github.PullRequestAutoMerge{}, Links:github.PRLinks{}, Head:github.PullRequestBranch{}, Base:github.PullRequestBranch{}, ActiveLockReason:""}`
+	want := `github.PullRequest{ID:0, Number:0, State:"", Locked:false, Title:"", Body:"", CreatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, UpdatedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, ClosedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, MergedAt:github.Timestamp{0001-01-01 00:00:00 +0000 UTC}, User:github.User{}, Draft:false, Merged:false, Mergeable:false, MergeableState:"", MergedBy:github.User{}, MergeCommitSHA:"", Rebaseable:false, Comments:0, Commits:0, Additions:0, Deletions:0, ChangedFiles:0, URL:"", HTMLURL:"", IssueURL:"", StatusesURL:"", DiffURL:"", PatchURL:"", CommitsURL:"", CommentsURL:"", ReviewCommentsURL:"", ReviewCommentURL:"", ReviewComments:0, Assignee:github.User{}, Milestone:github.Milestone{}, AuthorAssociation:"", NodeID:"", AutoMerge:github.PullRequestAutoMerge{}, Links:github.PRLinks{}, Head:github.PullRequestBranch{}, Base:github.PullRequestBranch{}, ActiveLockReason:""}`
 	if got := v.String(); got != want {
 		t.Errorf("PullRequest.String = %v, want %v", got, want)
 	}

--- a/github/pulls.go
+++ b/github/pulls.go
@@ -27,49 +27,48 @@ type PullRequestAutoMerge struct {
 
 // PullRequest represents a GitHub pull request on a repository.
 type PullRequest struct {
-	ID                  *int64                `json:"id,omitempty"`
-	Number              *int                  `json:"number,omitempty"`
-	State               *string               `json:"state,omitempty"`
-	Locked              *bool                 `json:"locked,omitempty"`
-	Title               *string               `json:"title,omitempty"`
-	Body                *string               `json:"body,omitempty"`
-	CreatedAt           *Timestamp            `json:"created_at,omitempty"`
-	UpdatedAt           *Timestamp            `json:"updated_at,omitempty"`
-	ClosedAt            *Timestamp            `json:"closed_at,omitempty"`
-	MergedAt            *Timestamp            `json:"merged_at,omitempty"`
-	Labels              []*Label              `json:"labels,omitempty"`
-	User                *User                 `json:"user,omitempty"`
-	Draft               *bool                 `json:"draft,omitempty"`
-	Merged              *bool                 `json:"merged,omitempty"`
-	Mergeable           *bool                 `json:"mergeable,omitempty"`
-	MergeableState      *string               `json:"mergeable_state,omitempty"`
-	MergedBy            *User                 `json:"merged_by,omitempty"`
-	MergeCommitSHA      *string               `json:"merge_commit_sha,omitempty"`
-	Rebaseable          *bool                 `json:"rebaseable,omitempty"`
-	Comments            *int                  `json:"comments,omitempty"`
-	Commits             *int                  `json:"commits,omitempty"`
-	Additions           *int                  `json:"additions,omitempty"`
-	Deletions           *int                  `json:"deletions,omitempty"`
-	ChangedFiles        *int                  `json:"changed_files,omitempty"`
-	URL                 *string               `json:"url,omitempty"`
-	HTMLURL             *string               `json:"html_url,omitempty"`
-	IssueURL            *string               `json:"issue_url,omitempty"`
-	StatusesURL         *string               `json:"statuses_url,omitempty"`
-	DiffURL             *string               `json:"diff_url,omitempty"`
-	PatchURL            *string               `json:"patch_url,omitempty"`
-	CommitsURL          *string               `json:"commits_url,omitempty"`
-	CommentsURL         *string               `json:"comments_url,omitempty"`
-	ReviewCommentsURL   *string               `json:"review_comments_url,omitempty"`
-	ReviewCommentURL    *string               `json:"review_comment_url,omitempty"`
-	ReviewComments      *int                  `json:"review_comments,omitempty"`
-	Assignee            *User                 `json:"assignee,omitempty"`
-	Assignees           []*User               `json:"assignees,omitempty"`
-	Milestone           *Milestone            `json:"milestone,omitempty"`
-	MaintainerCanModify *bool                 `json:"maintainer_can_modify,omitempty"`
-	AuthorAssociation   *string               `json:"author_association,omitempty"`
-	NodeID              *string               `json:"node_id,omitempty"`
-	RequestedReviewers  []*User               `json:"requested_reviewers,omitempty"`
-	AutoMerge           *PullRequestAutoMerge `json:"auto_merge,omitempty"`
+	ID                 *int64                `json:"id,omitempty"`
+	Number             *int                  `json:"number,omitempty"`
+	State              *string               `json:"state,omitempty"`
+	Locked             *bool                 `json:"locked,omitempty"`
+	Title              *string               `json:"title,omitempty"`
+	Body               *string               `json:"body,omitempty"`
+	CreatedAt          *Timestamp            `json:"created_at,omitempty"`
+	UpdatedAt          *Timestamp            `json:"updated_at,omitempty"`
+	ClosedAt           *Timestamp            `json:"closed_at,omitempty"`
+	MergedAt           *Timestamp            `json:"merged_at,omitempty"`
+	Labels             []*Label              `json:"labels,omitempty"`
+	User               *User                 `json:"user,omitempty"`
+	Draft              *bool                 `json:"draft,omitempty"`
+	Merged             *bool                 `json:"merged,omitempty"`
+	Mergeable          *bool                 `json:"mergeable,omitempty"`
+	MergeableState     *string               `json:"mergeable_state,omitempty"`
+	MergedBy           *User                 `json:"merged_by,omitempty"`
+	MergeCommitSHA     *string               `json:"merge_commit_sha,omitempty"`
+	Rebaseable         *bool                 `json:"rebaseable,omitempty"`
+	Comments           *int                  `json:"comments,omitempty"`
+	Commits            *int                  `json:"commits,omitempty"`
+	Additions          *int                  `json:"additions,omitempty"`
+	Deletions          *int                  `json:"deletions,omitempty"`
+	ChangedFiles       *int                  `json:"changed_files,omitempty"`
+	URL                *string               `json:"url,omitempty"`
+	HTMLURL            *string               `json:"html_url,omitempty"`
+	IssueURL           *string               `json:"issue_url,omitempty"`
+	StatusesURL        *string               `json:"statuses_url,omitempty"`
+	DiffURL            *string               `json:"diff_url,omitempty"`
+	PatchURL           *string               `json:"patch_url,omitempty"`
+	CommitsURL         *string               `json:"commits_url,omitempty"`
+	CommentsURL        *string               `json:"comments_url,omitempty"`
+	ReviewCommentsURL  *string               `json:"review_comments_url,omitempty"`
+	ReviewCommentURL   *string               `json:"review_comment_url,omitempty"`
+	ReviewComments     *int                  `json:"review_comments,omitempty"`
+	Assignee           *User                 `json:"assignee,omitempty"`
+	Assignees          []*User               `json:"assignees,omitempty"`
+	Milestone          *Milestone            `json:"milestone,omitempty"`
+	AuthorAssociation  *string               `json:"author_association,omitempty"`
+	NodeID             *string               `json:"node_id,omitempty"`
+	RequestedReviewers []*User               `json:"requested_reviewers,omitempty"`
+	AutoMerge          *PullRequestAutoMerge `json:"auto_merge,omitempty"`
 
 	// RequestedTeams is populated as part of the PullRequestEvent.
 	// See, https://docs.github.com/developers/webhooks-and-events/github-event-types#pullrequestevent for an example.
@@ -250,14 +249,13 @@ func (s *PullRequestsService) GetRaw(ctx context.Context, owner string, repo str
 
 // NewPullRequest represents a new pull request to be created.
 type NewPullRequest struct {
-	Title               *string `json:"title,omitempty"`
-	Head                *string `json:"head,omitempty"`
-	HeadRepo            *string `json:"head_repo,omitempty"`
-	Base                *string `json:"base,omitempty"`
-	Body                *string `json:"body,omitempty"`
-	Issue               *int    `json:"issue,omitempty"`
-	MaintainerCanModify *bool   `json:"maintainer_can_modify,omitempty"`
-	Draft               *bool   `json:"draft,omitempty"`
+	Title    *string `json:"title,omitempty"`
+	Head     *string `json:"head,omitempty"`
+	HeadRepo *string `json:"head_repo,omitempty"`
+	Base     *string `json:"base,omitempty"`
+	Body     *string `json:"body,omitempty"`
+	Issue    *int    `json:"issue,omitempty"`
+	Draft    *bool   `json:"draft,omitempty"`
 }
 
 // Create a new pull request on the specified repository.
@@ -327,17 +325,16 @@ func (s *PullRequestsService) UpdateBranch(ctx context.Context, owner, repo stri
 }
 
 type pullRequestUpdate struct {
-	Title               *string `json:"title,omitempty"`
-	Body                *string `json:"body,omitempty"`
-	State               *string `json:"state,omitempty"`
-	Base                *string `json:"base,omitempty"`
-	MaintainerCanModify *bool   `json:"maintainer_can_modify,omitempty"`
+	Title *string `json:"title,omitempty"`
+	Body  *string `json:"body,omitempty"`
+	State *string `json:"state,omitempty"`
+	Base  *string `json:"base,omitempty"`
 }
 
 // Edit a pull request.
 // pull must not be nil.
 //
-// The following fields are editable: Title, Body, State, Base.Ref and MaintainerCanModify.
+// The following fields are editable: Title, Body, State and Base.Ref.
 // Base.Ref updates the base branch of the pull request.
 //
 // GitHub API docs: https://docs.github.com/rest/pulls/pulls#update-a-pull-request
@@ -351,10 +348,9 @@ func (s *PullRequestsService) Edit(ctx context.Context, owner string, repo strin
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d", owner, repo, number)
 
 	update := &pullRequestUpdate{
-		Title:               pull.Title,
-		Body:                pull.Body,
-		State:               pull.State,
-		MaintainerCanModify: pull.MaintainerCanModify,
+		Title: pull.Title,
+		Body:  pull.Body,
+		State: pull.State,
 	}
 	// avoid updating the base branch when closing the Pull Request
 	// - otherwise the GitHub API server returns a "Validation Failed" error:

--- a/github/pulls_test.go
+++ b/github/pulls_test.go
@@ -880,11 +880,10 @@ func TestPullRequestUpdate_Marshal(t *testing.T) {
 	testJSONMarshal(t, &pullRequestUpdate{}, "{}")
 
 	u := &pullRequestUpdate{
-		Title:               String("title"),
-		Body:                String("body"),
-		State:               String("state"),
-		Base:                String("base"),
-		MaintainerCanModify: Bool(false),
+		Title: String("title"),
+		Body:  String("body"),
+		State: String("state"),
+		Base:  String("base"),
 	}
 
 	want := `{
@@ -892,7 +891,6 @@ func TestPullRequestUpdate_Marshal(t *testing.T) {
 		"body": "body",
 		"state": "state",
 		"base": "base",
-		"maintainer_can_modify": false
 	}`
 
 	testJSONMarshal(t, u, want)
@@ -932,14 +930,13 @@ func TestNewPullRequest_Marshal(t *testing.T) {
 	testJSONMarshal(t, &NewPullRequest{}, "{}")
 
 	u := &NewPullRequest{
-		Title:               String("eh"),
-		Head:                String("eh"),
-		HeadRepo:            String("eh"),
-		Base:                String("eh"),
-		Body:                String("eh"),
-		Issue:               Int(1),
-		MaintainerCanModify: Bool(false),
-		Draft:               Bool(false),
+		Title:    String("eh"),
+		Head:     String("eh"),
+		HeadRepo: String("eh"),
+		Base:     String("eh"),
+		Body:     String("eh"),
+		Issue:    Int(1),
+		Draft:    Bool(false),
 	}
 
 	want := `{
@@ -949,7 +946,6 @@ func TestNewPullRequest_Marshal(t *testing.T) {
 		"base": "eh",
 		"body": "eh",
 		"issue": 1,
-		"maintainer_can_modify": false,
 		"draft": false
 	}`
 
@@ -1269,10 +1265,9 @@ func TestPullRequest_Marshal(t *testing.T) {
 				SuspendedAt:     &Timestamp{referenceTime},
 			},
 		},
-		Milestone:           &Milestone{ID: Int64(1)},
-		MaintainerCanModify: Bool(true),
-		AuthorAssociation:   String("aa"),
-		NodeID:              String("nid"),
+		Milestone:         &Milestone{ID: Int64(1)},
+		AuthorAssociation: String("aa"),
+		NodeID:            String("nid"),
 		RequestedReviewers: []*User{
 			{
 				Login:           String("l"),
@@ -1481,7 +1476,6 @@ func TestPullRequest_Marshal(t *testing.T) {
 		"milestone": {
 			"id": 1
 		},
-		"maintainer_can_modify": true,
 		"author_association": "aa",
 		"node_id": "nid",
 		"requested_reviewers": [


### PR DESCRIPTION
This removes all mentioned of `MaintainerCanModify` and `maintainer_can_modify` fields from the library, which essentially blocks PRs under organization repos from being modified by people with `Admin` or `Maintain` privilege. This behavior has been confirmed as unexpected by Github Support, hence this fork was made.